### PR TITLE
Move ingress-class from annotation to ingressClassName

### DIFF
--- a/k8s/base/application-ingress.yml
+++ b/k8s/base/application-ingress.yml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: <APPLICATION_NAME>-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
+  ingressClassName: nginx
   rules:
   - host: "open-dev.vreview.io"
     http:


### PR DESCRIPTION
### Summary

beta1에서 v1으로 변경되면서, annotation.class는 deprecated 되었기 때문에 변경합니다.