### PR TITLE
Add node affinity

### DIFF
--- a/k8s/environments/dev/application-depl.yml
+++ b/k8s/environments/dev/application-depl.yml
@@ -4,3 +4,17 @@ metadata:
   name: <APPLICATION_NAME>-depl
 spec:
   replicas: 1
+  template:
+    metadata:
+      labels:
+        app: <APPLICATION_NAME>
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: environment
+                    operator: In
+                    values:
+                      - dev

--- a/k8s/environments/prod/application-depl.yml
+++ b/k8s/environments/prod/application-depl.yml
@@ -4,6 +4,20 @@ metadata:
   name: <APPLICATION_NAME>-depl
 spec:
   replicas: 4
+  template:
+    metadata:
+      labels:
+        app: <APPLICATION_NAME>
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: environment
+                    operator: In
+                    values:
+                      - prod
   containers:
     - name: <APPLICATION_NAME>
       envFrom:


### PR DESCRIPTION
### Summary
NodeGroup이 environment label을 활용하여 분리되었습니다. 따라서 환경별로 올바르게 배포되기 위해 node affinity를 추가합니다.